### PR TITLE
Fix bugs in initializing `self.cnndm` in `benchmark.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The SummaC Benchmark consists of 6 summary consistency datasets that have been s
 The data-loaders for the benchmark are included in `benchmark.py` ([link](https://github.com/tingofurro/summac/blob/master/summac/benchmark.py)). Each dataset in the benchmark downloads automatically on first run. To load the benchmark:
 ```py
 from summac.benchmark import SummaCBenchmark
-benchmark_val = SummaCBenchmark(benchmark_folder="/path/to/summac_benchmark/", cut="val")
+benchmark_val = SummaCBenchmark(benchmark_folder="/path/to/summac_benchmark/", cut="val", hf_datasets_cache_dir = "/path/to/huggingface_datasets_cache_dir/")
 frank_dataset = benchmark_val.get_dataset("frank")
 print(frank_dataset[300]) # {"document: "A Darwin woman has become a TV [...]", "claim": "natalia moon , 23 , has become a tv sensation [...]", "label": 0, "cut": "val", "model_name": "s2s", "error_type": "LinkE"}
 ```

--- a/summac/benchmark.py
+++ b/summac/benchmark.py
@@ -160,7 +160,8 @@ class SummaCBenchmark:
 
         clean_dataset = []
         
-        groups = dict(islice(groups.items(), 4))
+        if self.debug: 
+            groups = dict(islice(groups.items(), 4))
         for k, vs in tqdm(groups.items()):
             A = vs[0]
             document = self.get_xsum_document(A["bbcid"])
@@ -344,7 +345,7 @@ class SummaCBenchmark:
         dataset = []
 
         if self.debug:
-            raw_dataset = raw_dataset[:4]
+            raw_dataset = raw_dataset[:100]
         for d in tqdm(raw_dataset):
             article = d["article"]
             origin = "cnndm" if len(d["hash"]) >= 40 else "xsum"

--- a/summac/benchmark.py
+++ b/summac/benchmark.py
@@ -7,6 +7,8 @@ from .utils_misc import download_file_from_google_drive
 from  tqdm import tqdm
 from itertools import islice
 
+
+
 # SummaC Benchmark
 class SummaCBenchmark:
 
@@ -352,7 +354,7 @@ class SummaCBenchmark:
 
             summ_labels = []
             annotator_labels = {}
-            for annot in tqdm(d["summary_sentences_annotations"]):
+            for annot in d["summary_sentences_annotations"]:
                 annot_vals = [an for ans in annot.values() for an in ans]
                 noerror_count = len([an for an in annot_vals if an=="NoE"])
                 label = 1 if noerror_count >= 2 else 0
@@ -398,22 +400,6 @@ class SummaCBenchmark:
             benchmark.append({"name": dataset["name"], "score": dataset_f1, "threshold": dataset_thresh})
         return {"overall_score": np.mean([t["score"] for t in benchmark]), "benchmark": benchmark}
 
-    def  dump_datasets(self):
-        for dataset_name in dataset_names:
-            if dataset_name == "cogensum":
-                self.load_cogensumm()
-            elif dataset_name == "xsumfaith":
-                self.load_xsumfaith()
-            elif dataset_name == "polytope":
-                self.load_polytope()
-            elif dataset_name == "factcc":
-                self.load_factcc()
-            elif dataset_name == "summeval":
-                self.load_summeval()
-            elif dataset_name == "frank":
-                self.load_frank()
-            else:
-                raise ValueError("Unrecognized dataset name: %s" % (dataset_name))
 
 if __name__ == "__main__":
     import random

--- a/summac/benchmark.py
+++ b/summac/benchmark.py
@@ -69,7 +69,7 @@ class SummaCBenchmark:
 
     def get_xsum_document(self, aid):
         if self.xsum is None:
-            self.xsum = load_dataset("xsum", cache_dir=self.hf_datasets_cache_dir)["test"]
+            self.xsum = load_dataset("xsum", cache_dir=self.hf_datasets_cache_dir, trust_remote_code=True)["test"]
             self.xsumid2article = {d["id"]: d["document"] for d in self.xsum}
 
         return self.xsumid2article[aid]


### PR DESCRIPTION
**Critical change**: 

Below, lines 44 and 54 can cause an error due to `CNNDM` is undefined. 
And there is no need for the global variable `CNNDM` when `self.cnndm` presents. 

This bug fix uses only `self.cnndm` which is initialized to `None`. And when it is `none`, `self.get_cnndm_documents()` or `self.get_cnndm_references()` will populate it with real data. 

https://github.com/tingofurro/summac/blob/9e4f35722b635402c6fd5a1399d987bc80b45b43/summac/benchmark.py#L41-L56

**Non-critical change**: 
This fix also exposes `cache_dir` of Huggingface `datasets.load_datasets()`. 
