### PR TITLE
Convert histograms to nparray to avoid warning

### DIFF
--- a/summac/model_summac.py
+++ b/summac/model_summac.py
@@ -295,7 +295,7 @@ class SummaCConv(torch.nn.Module):
                 histograms.append(histogram)
 
         N = len(histograms)
-        histograms = torch.FloatTensor(histograms).to(self.device)
+        histograms = torch.FloatTensor(np.array(histograms)).to(self.device)
 
         non_zeros = (torch.sum(histograms, dim=-1) != 0.0).long()
         seq_lengths = non_zeros.sum(dim=-1).tolist()


### PR DESCRIPTION
torch throws a warning about creating a tensor from a list of arrays:
```
summac/model_summac.py:301: UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor. (Triggered internally at ../torch/csrc/utils/tensor_new.cpp:261.)
  histograms = torch.FloatTensor(histograms).to(self.device)
```

This PR converts the list to a single nparray first to avoid this message. I've not noticed a significant change in performance as a result.